### PR TITLE
Embed static assets to prepare for standalone releases

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,6 +2,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - '*'
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: |
           sudo apt-get update
-          sudo apt-get install -y clang llvm
+          sudo apt-get install -y clang llvm lld
       - name: setup ripgrep
         uses: lmaotrigine/fetch-crate-action@mistress
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,97 @@
+on:
+  push:
+    tags:
+      - '*'
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  release:
+    strategy:
+      matrix:
+        target:
+          - aarch64-apple-darwin
+          - aarch64-unknown-linux-musl
+          - arm-unknown-linux-musleabihf
+          - armv7-unknown-linux-musleabihf
+          - x86_64-apple-darwin
+          - x86_64-pc-windows-msvc
+          - x86_64-unknown-linux-musl
+        include:
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            target-rustflags: ''
+          - target: aarch64-unknown-linux-musl
+            os: ubuntu-latest
+            target-rustflags: '-C linker=lld'
+          - target: arm-unknown-linux-musleabihf
+            os: ubuntu-latest
+            target-rustflags: '-C linker=lld'
+          - target: armv7-unknown-linux-musleabihf
+            os: ubuntu-latest
+            target-rustflags: '-C linker=lld'
+          - target: x86_64-apple-darwin
+            os: macos-latest
+            target-rustflags: ''
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+            target-rustflags: ''
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+            target-rustflags: '-C linker=lld'
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@master
+        with:
+          fetch-depth: 1  # we don't build pre-releases anyway
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}
+      - name: setup stable rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+          target: ${{ matrix.target }}
+      - name: install llvm toolchains
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang llvm
+      - name: setup ripgrep
+        uses: lmaotrigine/fetch-crate-action@mistress
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          owner: BurntSushi
+          name: ripgrep
+          bin: rg
+      - name: ref type
+        id: ref-type
+        run: ./bin/ref-type ${{ github.ref }} >> "$GITHUB_OUTPUT"
+      - name: package
+        id: package
+        env:
+          TARGET: ${{ matrix.target }}
+          REF: ${{ github.ref }}
+          OS: ${{ matrix.os }}
+          TARGET_RUSTFLAGS: ${{ matrix.target-rustflags }}
+        run: ./bin/package
+        shell: bash
+      - name: publish archive
+        uses: softprops/action-gh-release@v1
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
+        with:
+          draft: true
+          files: ${{ steps.package.outputs.archive }}
+          prerelease: ${{ steps.ref-type.outputs.value != 'release' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+        

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ db_data/
 
 # soon:tm:
 contrib/
+
+# packages
+dist/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -733,9 +733,12 @@ dependencies = [
  "html",
  "include_dir",
  "itoa",
+ "mime_guess",
  "parking_lot",
+ "percent-encoding",
  "rand",
  "reqwest",
+ "rust-embed",
  "serde",
  "serde_json",
  "sqlx",
@@ -841,9 +844,9 @@ dependencies = [
 
 [[package]]
 name = "http-range-header"
-version = "0.4.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ce4ef31cda248bbdb6e6820603b82dfcd9e833db65a43e997a0ccec777d11fe"
+checksum = "add0ab9360ddbd88cfeb3bd9574a1d85cfdfa14db10b3e21d3700dbc4328758f"
 
 [[package]]
 name = "httparse"
@@ -1491,6 +1494,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-embed"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e7d90385b59f0a6bf3d3b757f3ca4ece2048265d70db20a2016043d4509a40"
+dependencies = [
+ "rust-embed-impl",
+ "rust-embed-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3d8c6fd84090ae348e63a84336b112b5c3918b3bf0493a581f7bd8ee623c29"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rust-embed-utils",
+ "syn 2.0.38",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "873feff8cb7bf86fdf0a71bb21c95159f4e4a37dd7a4bd1855a940909b583ada"
+dependencies = [
+ "sha2",
+ "walkdir",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1551,6 +1588,15 @@ name = "ryu"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "scopeguard"
@@ -2206,7 +2252,8 @@ dependencies = [
 [[package]]
 name = "tower-http"
 version = "0.4.4"
-source = "git+https://github.com/lmaotrigine/tower-http?branch=serve-dir-backend#4478b645d5f2068355c6e36cc1335bc11ee4dfc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c5bb1d698276a2443e5ecfabc1008bf15a36c12e6a7176e7bf089ea9131140"
 dependencies = [
  "bitflags 2.4.1",
  "bytes",
@@ -2215,14 +2262,7 @@ dependencies = [
  "http",
  "http-body",
  "http-range-header",
- "httpdate",
- "include_dir",
- "mime",
- "mime_guess",
- "percent-encoding",
  "pin-project-lite",
- "tokio",
- "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -2431,6 +2471,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
+name = "walkdir"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2557,6 +2607,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,14 +19,15 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.8.3"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
 dependencies = [
  "cfg-if",
  "getrandom",
  "once_cell",
  "version_check",
+ "zerocopy",
 ]
 
 [[package]]
@@ -188,9 +189,9 @@ source = "git+https://github.com/lmaotrigine/badges#3e42321ac444a085dcd9c4f0d80f
 
 [[package]]
 name = "base64"
-version = "0.21.4"
+version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
+checksum = "35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9"
 
 [[package]]
 name = "base64ct"
@@ -270,9 +271,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.6"
+version = "4.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d04704f56c2cde07f43e8e2c154b43f216dc5c92fc98ada720177362f953b956"
+checksum = "ac495e00dcec98c83465d5ad66c5c4fabd652fd6686e7c6269b117e729a6f17b"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -280,9 +281,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.6"
+version = "4.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e231faeaca65ebd1ea3c737966bf858971cd38c3849107aa3ea7de90a804e45"
+checksum = "c77ed9a32a62e6ca27175d00d29d05ca32e396ea1eb5fb01d8256b669cec7663"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -290,9 +291,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.4.2"
+version = "4.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0862016ff20d69b84ef8247369fabf5c008a7417002411897d40ee1f4532b873"
+checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -302,9 +303,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
+checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 
 [[package]]
 name = "color-eyre"
@@ -357,9 +358,9 @@ checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fbc60abd742b35f2492f808e1abbb83d45f72db402e14c55057edc9c7b1e9e4"
+checksum = "ce420fe07aecd3e67c5f910618fe65e94158f6dcc0adf44e00d69ce2bdfe0fd0"
 dependencies = [
  "libc",
 ]
@@ -552,9 +553,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
+checksum = "ff4dd66668b557604244583e3e1e1eada8c5c2e96a6d0d6653ede395b78bbacb"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -562,15 +563,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
+checksum = "eb1d22c66e66d9d72e1758f0bd7d4fd0bee04cad842ee34587d68c07e45d088c"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
+checksum = "0f4fb8693db0cf099eadcca0efe2a5a22e4550f98ed16aba6c48700da29597bc"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -590,42 +591,30 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
-
-[[package]]
-name = "futures-macro"
-version = "0.3.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.38",
-]
+checksum = "8bf34a163b5c4c52d0478a4d757da8fb65cabef42ba90515efee0f6f9fa45aaa"
 
 [[package]]
 name = "futures-sink"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
+checksum = "e36d3378ee38c2a36ad710c5d30c2911d752cb941c00c72dbabfb786a7970817"
 
 [[package]]
 name = "futures-task"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
+checksum = "efd193069b0ddadc69c46389b740bbccdd97203899b48d09c5f7969591d6bae2"
 
 [[package]]
 name = "futures-util"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
+checksum = "a19526d624e703a3179b3d322efec918b6246ea0fa51d41124525f00f1cc8104"
 dependencies = [
  "futures-core",
  "futures-io",
- "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -893,9 +882,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d78e1e73ec14cf7375674f74d7dde185c8206fd9dea6fb6295e8a98098aaa97"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
  "http",
@@ -966,9 +955,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28b29a3cd74f0f4598934efe3aeba42bae0eb4680554128851ebbecb02af14e6"
+checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
 name = "itertools"
@@ -1103,9 +1092,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
+checksum = "3dce281c5e46beae905d4de1870d8b1509a9142b62eedf18b443b011ca8343d0"
 dependencies = [
  "libc",
  "wasi",
@@ -1235,7 +1224,7 @@ checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.4.1",
+ "redox_syscall",
  "smallvec",
  "windows-targets",
 ]
@@ -1400,15 +1389,6 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_syscall"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
@@ -1458,31 +1438,28 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.16.20"
+version = "0.17.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+checksum = "fb0205304757e5d899b9c2e448b867ffd03ae7f988002e47cd24954391394d0b"
 dependencies = [
  "cc",
+ "getrandom",
  "libc",
- "once_cell",
- "spin 0.5.2",
+ "spin 0.9.8",
  "untrusted",
- "web-sys",
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]
 name = "rsa"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ab43bb47d23c1a631b4b680199a45255dce26fa9ab2fa902581f624ff13e6a8"
+checksum = "86ef35bf3e7fe15a53c4ab08a998e42271eab13eb0db224126bc7bc4c4bad96d"
 dependencies = [
- "byteorder",
  "const-oid",
  "digest",
  "num-bigint-dig",
  "num-integer",
- "num-iter",
  "num-traits",
  "pkcs1",
  "pkcs8",
@@ -1501,9 +1478,9 @@ checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustix"
-version = "0.38.20"
+version = "0.38.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ce50cb2e16c2903e30d1cbccfd8387a74b9d4c938b6a4c5ec6cc7556f7a8a0"
+checksum = "2b426b0506e5d50a7d8dafcf2e81471400deb602392c7dd110815afb4eaf02a3"
 dependencies = [
  "bitflags 2.4.1",
  "errno",
@@ -1514,9 +1491,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.7"
+version = "0.21.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd8d6c9f025a446bc4d18ad9632e69aec8f287aa84499ee335599fabd20c3fd8"
+checksum = "446e14c5cda4f3f30fe71863c34ec70f5ac79d6087097ad0bb433e1be5edf04c"
 dependencies = [
  "log",
  "ring",
@@ -1535,9 +1512,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.6"
+version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c7d5dece342910d9ba34d259310cae3e0154b873b35408b787b59bce53d34fe"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring",
  "untrusted",
@@ -1563,9 +1540,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sct"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
  "ring",
  "untrusted",
@@ -1573,18 +1550,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.189"
+version = "1.0.190"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e422a44e74ad4001bdc8eede9a4570ab52f71190e9c076d14369f38b9200537"
+checksum = "91d3c334ca1ee894a2c6f6ad698fe8c435b76d504b13d436f0685d648d6d96f7"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.189"
+version = "1.0.190"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e48d1f918009ce3145511378cf68d613e3b3d9137d67272562080d68a2b32d5"
+checksum = "67c5609f394e5c2bd7fc51efda478004ea80ef42fee983d5c67a65e34f32c0e3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1593,9 +1570,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.107"
+version = "1.0.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
+checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
 dependencies = [
  "itoa",
  "ryu",
@@ -1614,9 +1591,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96426c9936fd7a0124915f9185ea1d20aa9445cc9821142f0a73bc9207a2e186"
+checksum = "12022b835073e5b11e90a14f86838ceb1c8fb0325b72416845c487ac0fa95e80"
 dependencies = [
  "serde",
 ]
@@ -2024,13 +2001,13 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.8.0"
+version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
+checksum = "7ef1adac450ad7f4b3c28589471ade84f25f731a7a0fe30d71dfa9f60fd808e5"
 dependencies = [
  "cfg-if",
  "fastrand",
- "redox_syscall 0.3.5",
+ "redox_syscall",
  "rustix",
  "windows-sys",
 ]
@@ -2144,9 +2121,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d68074620f57a0b21594d9735eb2e98ab38b17f80d3fcb189fca266771ca60d"
+checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2158,9 +2135,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.2"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "185d8ab0dfbb35cf1399a6344d8484209c088f75f8f68230da55d48d95d43e3d"
+checksum = "8ff9e3abce27ee2c9a37f9ad37238c1bdd4e789c84ba37df76aa4d528f5072cc"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -2170,18 +2147,18 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.20.2"
+version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
+checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
 dependencies = [
  "indexmap 2.0.2",
  "serde",
@@ -2288,12 +2265,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-log"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
+checksum = "f751112709b4e791d8ce53e32c4ed2d353565a795ce84da2285393f41557bdf2"
 dependencies = [
- "lazy_static",
  "log",
+ "once_cell",
  "tracing-core",
 ]
 
@@ -2394,9 +2371,9 @@ dependencies = [
 
 [[package]]
 name = "untrusted"
-version = "0.7.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -2644,9 +2621,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "winnow"
-version = "0.5.17"
+version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3b801d0e0a6726477cc207f60162da452f3a95adb368399bef20a946e06f65c"
+checksum = "176b6138793677221d420fd2f0aeeced263f197688b36484660da767bca2fa32"
 dependencies = [
  "memchr",
 ]
@@ -2659,6 +2636,26 @@ checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
  "cfg-if",
  "windows-sys",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.7.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd66a62464e3ffd4e37bd09950c2b9dd6c4f8767380fabba0d523f9a775bc85a"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "255c4596d41e6916ced49cfafea18727b24d67878fa180ddfd69b9df34fd1726"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.38",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -376,9 +376,9 @@ dependencies = [
 
 [[package]]
 name = "crc-catalog"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cace84e55f07e7301bae1c519df89cdad8cc3cd868413d3fdbdeca9ff3db484"
+checksum = "4939f9ed1444bd8c896d37f3090012fa6e7834fe84ef8c9daa166109515732f9"
 
 [[package]]
 name = "crossbeam-queue"
@@ -741,8 +741,7 @@ dependencies = [
  "sqlx",
  "tokio",
  "toml",
- "tower-http 0.3.5",
- "tower-http 0.4.4",
+ "tower-http",
  "tracing",
  "tracing-subscriber",
  "unsafe_formatting",
@@ -842,9 +841,9 @@ dependencies = [
 
 [[package]]
 name = "http-range-header"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "add0ab9360ddbd88cfeb3bd9574a1d85cfdfa14db10b3e21d3700dbc4328758f"
+checksum = "3ce4ef31cda248bbdb6e6820603b82dfcd9e833db65a43e997a0ccec777d11fe"
 
 [[package]]
 name = "httparse"
@@ -966,9 +965,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.0.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8adf3ddd720272c6ea8bf59463c04e0f93d0bbf7c5439b691bca2987e0270897"
+checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.2",
@@ -1788,7 +1787,7 @@ dependencies = [
  "futures-util",
  "hashlink",
  "hex",
- "indexmap 2.0.2",
+ "indexmap 2.1.0",
  "log",
  "memchr",
  "once_cell",
@@ -2181,7 +2180,7 @@ version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
 dependencies = [
- "indexmap 2.0.2",
+ "indexmap 2.1.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -2206,34 +2205,8 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.3.5"
-source = "git+https://github.com/lmaotrigine/tower-http?branch=serve-dir-backend#b41a1d3172b509173c1e080bc52b10006f751773"
-dependencies = [
- "bitflags 1.3.2",
- "bytes",
- "futures-core",
- "futures-util",
- "http",
- "http-body",
- "http-range-header",
- "httpdate",
- "include_dir",
- "mime",
- "mime_guess",
- "percent-encoding",
- "pin-project-lite",
- "tokio",
- "tokio-util",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tower-http"
 version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c5bb1d698276a2443e5ecfabc1008bf15a36c12e6a7176e7bf089ea9131140"
+source = "git+https://github.com/lmaotrigine/tower-http?branch=serve-dir-backend#4478b645d5f2068355c6e36cc1335bc11ee4dfc4"
 dependencies = [
  "bitflags 2.4.1",
  "bytes",
@@ -2243,6 +2216,7 @@ dependencies = [
  "http-body",
  "http-range-header",
  "httpdate",
+ "include_dir",
  "mime",
  "mime_guess",
  "percent-encoding",
@@ -2686,18 +2660,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.20"
+version = "0.7.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd66a62464e3ffd4e37bd09950c2b9dd6c4f8767380fabba0d523f9a775bc85a"
+checksum = "686b7e407015242119c33dab17b8f61ba6843534de936d94368856528eae4dcc"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.20"
+version = "0.7.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "255c4596d41e6916ced49cfafea18727b24d67878fa180ddfd69b9df34fd1726"
+checksum = "020f3dfe25dfc38dfea49ce62d5d45ecdd7f0d8a724fa63eb36b6eba4ec76806"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -741,7 +741,8 @@ dependencies = [
  "sqlx",
  "tokio",
  "toml",
- "tower-http",
+ "tower-http 0.3.5",
+ "tower-http 0.4.4",
  "tracing",
  "tracing-subscriber",
  "unsafe_formatting",
@@ -2217,6 +2218,31 @@ dependencies = [
  "http-range-header",
  "httpdate",
  "include_dir",
+ "mime",
+ "mime_guess",
+ "percent-encoding",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c5bb1d698276a2443e5ecfabc1008bf15a36c12e6a7176e7bf089ea9131140"
+dependencies = [
+ "bitflags 2.4.1",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-range-header",
+ "httpdate",
  "mime",
  "mime_guess",
  "percent-encoding",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -731,6 +731,7 @@ dependencies = [
  "color-eyre",
  "erased-debug",
  "html",
+ "include_dir",
  "itoa",
  "parking_lot",
  "rand",
@@ -925,6 +926,25 @@ checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
+]
+
+[[package]]
+name = "include_dir"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18762faeff7122e89e0857b02f7ce6fcc0d101d5e9ad2ad7846cc01d61b7f19e"
+dependencies = [
+ "include_dir_macros",
+]
+
+[[package]]
+name = "include_dir_macros"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b139284b5cf57ecfa712bcc66950bb635b31aff41c188e8a4cfc758eca374a3f"
+dependencies = [
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]
@@ -2185,11 +2205,10 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c5bb1d698276a2443e5ecfabc1008bf15a36c12e6a7176e7bf089ea9131140"
+version = "0.3.5"
+source = "git+https://github.com/lmaotrigine/tower-http?branch=serve-dir-backend#b41a1d3172b509173c1e080bc52b10006f751773"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 1.3.2",
  "bytes",
  "futures-core",
  "futures-util",
@@ -2197,6 +2216,7 @@ dependencies = [
  "http-body",
  "http-range-header",
  "httpdate",
+ "include_dir",
  "mime",
  "mime_guess",
  "percent-encoding",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,28 +25,24 @@ erased-debug = { git = "https://git.5ht2.me/lmaotrigine/erased-debug", version =
 html = { git = "https://git.5ht2.me/lmaotrigine/html-rs", version = "0.1.0", features = ["axum"] }
 include_dir = { version = "0.7", optional = true }
 itoa = "1"
+mime_guess = { version = "2.0.4", default-features = false }
 parking_lot = "0.12"
+percent-encoding = { version = "2.3.0", default-features = false }
 rand = { version = "0.8", default-features = false, features = ["getrandom"] }
 reqwest = { version = "0.11", features = ["json", "rustls-tls-webpki-roots"], optional = true, default-features = false }
+rust-embed = "8"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sqlx = { version = "0.7", features = ["chrono", "macros", "postgres", "runtime-tokio"], default-features = false }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal"] }
 toml = "0.8"
+tower-http = { version = "0.4", features = ["trace"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"
 unsafe_formatting = { git = "https://git.5ht2.me/lmaotrigine/unsafe_formatting", version = "0.1.0" }
 
-[dependencies.tower-http]
-git = "https://github.com/lmaotrigine/tower-http"
-branch = "serve-dir-backend"
-version = "0.4"
-features = ["fs", "trace"]
-package = "tower-http"
-
 [features]
 default = ["badges", "webhook"]
-embed = ["tower-http/include-dir", "include_dir"]
 badges = ["dep:badges"]
 webhook = ["reqwest"]
 migrate = ["sqlx/migrate"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ clap = { version = "4", default-features = false, features = ["derive", "env", "
 color-eyre = "0.6"
 erased-debug = { git = "https://git.5ht2.me/lmaotrigine/erased-debug", version = "0.1.0", features = ["serde"] }
 html = { git = "https://git.5ht2.me/lmaotrigine/html-rs", version = "0.1.0", features = ["axum"] }
+include_dir = "0.7.3"
 itoa = "1"
 parking_lot = "0.12"
 rand = { version = "0.8", default-features = false, features = ["getrandom"] }
@@ -32,7 +33,7 @@ serde_json = "1"
 sqlx = { version = "0.7", features = ["chrono", "macros", "postgres", "runtime-tokio"], default-features = false }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal"] }
 toml = "0.8"
-tower-http = { version = "0.4", features = ["fs", "trace"] }
+tower-http = { git = "https://github.com/lmaotrigine/tower-http", branch = "serve-dir-backend", version = "0.3.5", features = ["fs", "include-dir", "trace"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"
 unsafe_formatting = { git = "https://git.5ht2.me/lmaotrigine/unsafe_formatting", version = "0.1.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ clap = { version = "4", default-features = false, features = ["derive", "env", "
 color-eyre = "0.6"
 erased-debug = { git = "https://git.5ht2.me/lmaotrigine/erased-debug", version = "0.1.0", features = ["serde"] }
 html = { git = "https://git.5ht2.me/lmaotrigine/html-rs", version = "0.1.0", features = ["axum"] }
-include_dir = "0.7.3"
+include_dir = { version = "0.7", optional = true }
 itoa = "1"
 parking_lot = "0.12"
 rand = { version = "0.8", default-features = false, features = ["getrandom"] }
@@ -33,13 +33,23 @@ serde_json = "1"
 sqlx = { version = "0.7", features = ["chrono", "macros", "postgres", "runtime-tokio"], default-features = false }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal"] }
 toml = "0.8"
-tower-http = { git = "https://github.com/lmaotrigine/tower-http", branch = "serve-dir-backend", version = "0.3.5", features = ["fs", "include-dir", "trace"] }
+tower-http = { version = "0.4", features = ["fs", "trace"], optional = true }
 tracing = "0.1"
 tracing-subscriber = "0.3"
 unsafe_formatting = { git = "https://git.5ht2.me/lmaotrigine/unsafe_formatting", version = "0.1.0" }
 
+[dependencies.tower-http-include-dir]
+git = "https://github.com/lmaotrigine/tower-http"
+branch = "serve-dir-backend"
+version = "0.3"
+features = ["fs", "include-dir", "trace"]
+package = "tower-http"
+optional = true
+
 [features]
-default = ["badges", "webhook"]
+default = ["badges", "webhook", "fs"]
+fs = ["tower-http"]
+embed = ["tower-http-include-dir", "include_dir"]
 badges = ["dep:badges"]
 webhook = ["reqwest"]
 migrate = ["sqlx/migrate"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,23 +33,20 @@ serde_json = "1"
 sqlx = { version = "0.7", features = ["chrono", "macros", "postgres", "runtime-tokio"], default-features = false }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal"] }
 toml = "0.8"
-tower-http = { version = "0.4", features = ["fs", "trace"], optional = true }
 tracing = "0.1"
 tracing-subscriber = "0.3"
 unsafe_formatting = { git = "https://git.5ht2.me/lmaotrigine/unsafe_formatting", version = "0.1.0" }
 
-[dependencies.tower-http-include-dir]
+[dependencies.tower-http]
 git = "https://github.com/lmaotrigine/tower-http"
 branch = "serve-dir-backend"
-version = "0.3"
-features = ["fs", "include-dir", "trace"]
+version = "0.4"
+features = ["fs", "trace"]
 package = "tower-http"
-optional = true
 
 [features]
-default = ["badges", "webhook", "fs"]
-fs = ["tower-http"]
-embed = ["tower-http-include-dir", "include_dir"]
+default = ["badges", "webhook"]
+embed = ["tower-http/include-dir", "include_dir"]
 badges = ["dep:badges"]
 webhook = ["reqwest"]
 migrate = ["sqlx/migrate"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,8 @@ LABEL org.opencontainers.image.description "A service to show a live digital hea
 LABEL org.opencontainers.image.licenses "MPL-2.0"
 
 COPY --from=build /usr/src/app/target/release/heartbeat /usr/local/bin/heartbeat
+COPY --from=build /usr/src/app/static /usr/local/share/heartbeat/static
+WORKDIR /usr/local/share/heartbeat
 
 # test if the binary works
 RUN [ "/usr/local/bin/heartbeat", "--version" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,6 @@ LABEL org.opencontainers.image.description "A service to show a live digital hea
 LABEL org.opencontainers.image.licenses "MPL-2.0"
 
 COPY --from=build /usr/src/app/target/release/heartbeat /usr/local/bin/heartbeat
-COPY --from=build /usr/src/app/static /usr/local/share/heartbeat/static
 WORKDIR /usr/local/share/heartbeat
 
 # test if the binary works

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,9 +56,6 @@ LABEL org.opencontainers.image.description "A service to show a live digital hea
 LABEL org.opencontainers.image.licenses "MPL-2.0"
 
 COPY --from=build /usr/src/app/target/release/heartbeat /usr/local/bin/heartbeat
-COPY --from=build /usr/src/app/static /usr/local/share/heartbeat/static
-
-WORKDIR /usr/local/share/heartbeat
 
 # test if the binary works
 RUN [ "/usr/local/bin/heartbeat", "--version" ]

--- a/bin/package
+++ b/bin/package
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euxo pipefail
 

--- a/bin/package
+++ b/bin/package
@@ -26,7 +26,7 @@ EXES=(target/"$TARGET"/release/{heartbeat,generate_secret,migrate_db}"$EXE_SUFFI
 echo "Copying release files..."
 mkdir "$DIST"
 cp -r docs "$DIST/docs"
-cp LICENSE README.md "${EXES[@]}" "$DIST"
+cp LICENSE README.md config.example.toml "${EXES[@]}" "$DIST"
 
 cd "$DIST"
 echo "Creating release archive..."

--- a/bin/package
+++ b/bin/package
@@ -39,6 +39,6 @@ case "$OS" in
   windows-latest)
     ARCHIVE=$DIST/heartbeat-$VERSION-$TARGET.zip
     7z a "$ARCHIVE" ./*
-    echo "archive=$ARCHIVE" >> "$GITHUB_OUTPUT"
+    echo "archive=$(pwd -W)/heartbeat-$VERSION-$TARGET.zip" >> "$GITHUB_OUTPUT"
     ;;
 esac

--- a/bin/package
+++ b/bin/package
@@ -13,8 +13,10 @@ echo "Building heartbeat..."
 # for ring
 export CC_aarch64_unknown_linux_musl=clang
 export CC_armv7_unknown_linux_musleabihf=clang
+export CC_x86_64_unknown_linux_musl=clang
 export AR_aarch64_unknown_linux_musl=llvm-ar
 export AR_armv7_unknown_linux_musleabihf=llvm-ar
+export AR_x86_64_unknown_linux_musl=llvm-ar
 
 RUSTFLAGS="-D warnings -C target-feature=+crt-static $TARGET_RUSTFLAGS" \
   cargo build --target "$TARGET" --release --all-features --locked

--- a/bin/package
+++ b/bin/package
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+VERSION=${REF#"refs/tags/"}
+DIST=$(pwd)/dist
+
+echo "Packaging heartbeat $VERSION for $TARGET..."
+
+test -f Cargo.lock || cargo generate-lockfile
+
+echo "Building heartbeat..."
+# for ring
+export CC_aarch64_unknown_linux_musl=clang
+export CC_armv7_unknown_linux_musleabihf=clang
+export AR_aarch64_unknown_linux_musl=llvm-ar
+export AR_armv7_unknown_linux_musleabihf=llvm-ar
+
+RUSTFLAGS="-D warnings -C target-feature=+crt-static $TARGET_RUSTFLAGS" \
+  cargo build --target "$TARGET" --release --all-features --locked
+if [[ "$OS" = windows-latest ]]; then
+  EXE_SUFFIX=.exe
+else
+  EXE_SUFFIX=
+fi
+EXES=(target/"$TARGET"/release/{heartbeat,generate_secret,migrate_db}"$EXE_SUFFIX")
+echo "Copying release files..."
+mkdir "$DIST"
+cp -r docs "$DIST/docs"
+cp LICENSE README.md "${EXES[@]}" "$DIST"
+
+cd "$DIST"
+echo "Creating release archive..."
+case "$OS" in
+  ubuntu-latest | macos-latest)
+    ARCHIVE=$DIST/heartbeat-$VERSION-$TARGET.tar.xz
+    tar cJf "$ARCHIVE" ./*
+    echo "archive=$ARCHIVE" >> "$GITHUB_OUTPUT"
+    ;;
+  windows-latest)
+    ARCHIVE=$DIST/heartbeat-$VERSION-$TARGET.zip
+    7z a "$ARCHIVE" ./*
+    echo "archive=$ARCHIVE" >> "$GITHUB_OUTPUT"
+    ;;
+esac

--- a/bin/package
+++ b/bin/package
@@ -11,13 +11,10 @@ test -f Cargo.lock || cargo generate-lockfile
 
 echo "Building heartbeat..."
 # for ring
-export CC_aarch64_unknown_linux_musl=clang
-export CC_armv7_unknown_linux_musleabihf=clang
-export CC_x86_64_unknown_linux_musl=clang
-export AR_aarch64_unknown_linux_musl=llvm-ar
-export AR_armv7_unknown_linux_musleabihf=llvm-ar
-export AR_x86_64_unknown_linux_musl=llvm-ar
-
+if [[ "$OS" = ubuntu-latest ]]; then
+  export TARGET_CC=clang
+  export TARGET_AR=llvm-ar
+fi
 RUSTFLAGS="-D warnings -C target-feature=+crt-static $TARGET_RUSTFLAGS" \
   cargo build --target "$TARGET" --release --all-features --locked
 if [[ "$OS" = windows-latest ]]; then

--- a/bin/ref-type
+++ b/bin/ref-type
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euxo pipefail
 

--- a/bin/ref-type
+++ b/bin/ref-type
@@ -5,7 +5,7 @@ set -euxo pipefail
 which rg  > /dev/null
 
 if echo "$1" | rg -q '^refs/tags/[[:digit:]]+[.][[:digit:]]+[.][[:digit:]]+$'; then
-  echo "release"
+  echo "value=release"
 else
-  echo "other"
+  echo "value=other"
 fi

--- a/bin/ref-type
+++ b/bin/ref-type
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+which rg  > /dev/null
+
+if echo "$1" | rg -q '^refs/tags/[[:digit:]]+[.][[:digit:]]+[.][[:digit:]]+$'; then
+  echo "release"
+else
+  echo "other"
+fi

--- a/src/bin/web.rs
+++ b/src/bin/web.rs
@@ -32,14 +32,13 @@ async fn main() -> Result<()> {
     info!(config = ?config, "Loaded config");
     let bind = config.bind;
     let router = router(&config);
-    let static_dir = config.static_dir.clone();
     let app_state = AppState::from_config(config).await?;
     let trace_service = TraceLayer::new_for_http()
         .make_span_with(DefaultMakeSpan::new().level(Level::INFO))
         .on_response(DefaultOnResponse::new().level(Level::INFO));
     let router = router
         .with_state(app_state.clone())
-        .fallback_service(ServeDir::new(static_dir))
+        .fallback_service(ServeDir::from_include_dir(&heartbeat::ASSETS))
         .layer(middleware::from_fn_with_state(app_state, handle_errors))
         .layer(trace_service);
     let graceful_shutdown = async {

--- a/src/bin/web.rs
+++ b/src/bin/web.rs
@@ -16,13 +16,7 @@
 use axum::{middleware, Server};
 use color_eyre::eyre::Result;
 use std::net::SocketAddr;
-#[cfg(not(feature = "embed"))]
 use tower_http::{
-    services::ServeDir,
-    trace::{DefaultMakeSpan, DefaultOnResponse, TraceLayer},
-};
-#[cfg(feature = "embed")]
-use tower_http_include_dir::{
     services::ServeDir,
     trace::{DefaultMakeSpan, DefaultOnResponse, TraceLayer},
 };

--- a/src/config.rs
+++ b/src/config.rs
@@ -53,20 +53,6 @@ pub struct Cli {
     /// The bind address for the server.
     #[clap(long, short, env = "HEARTBEAT_BIND")]
     pub bind: Option<SocketAddr>,
-    // Not gating this behind `not(feature = "embed")` because rust-analyzer
-    // doesn't understand it.
-    // probably because of https://github.com/rust-lang/rust-analyzer/issues/8434
-    // instead we just explain that it does nothing in the help text.
-    #[cfg_attr(
-        not(feature = "embed"),
-        doc = "Path to the directory containing static assets. [default: ./static]"
-    )]
-    #[cfg_attr(
-        feature = "embed",
-        doc = "This option is ignored because this binary has static assets embedded in it."
-    )]
-    #[clap(long, env = "HEARTBEAT_STATIC_DIR")]
-    pub static_dir: Option<PathBuf>,
     /// The path to the configuration file. [default: ./config.toml]
     #[clap(long, short = 'c', env = "HEARTBEAT_CONFIG_FILE")]
     pub config_file: Option<PathBuf>,
@@ -92,9 +78,6 @@ pub struct Config {
     pub live_url: String,
     /// The bind address for the server.
     pub bind: SocketAddr,
-    /// Path to the directory containing static files.
-    #[cfg(not(feature = "embed"))]
-    pub static_dir: PathBuf,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -246,9 +229,6 @@ impl<'a> Merge<'a> {
         SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 6060))
     );
 
-    #[cfg(not(feature = "embed"))]
-    config_field!(static_dir, PathBuf, PathBuf::from("./static"));
-
     fn profile_value<T: Debug + Deserialize<'a>>(&self, field: &'a str) -> Option<T> {
         let value = self
             .toml
@@ -315,8 +295,6 @@ impl<'a> Merge<'a> {
             server_name: self.server_name()?,
             live_url: self.live_url()?,
             bind: self.bind()?,
-            #[cfg(not(feature = "embed"))]
-            static_dir: self.static_dir()?,
         })
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -53,6 +53,10 @@ pub struct Cli {
     /// The bind address for the server.
     #[clap(long, short, env = "HEARTBEAT_BIND")]
     pub bind: Option<SocketAddr>,
+    /// Path to the directory containing static assets. [default: ./static]
+    #[cfg(not(feature = "embed"))]
+    #[cfg_attr(not(feature = "embed"), clap(long, env = "HEARTBEAT_STATIC_DIR"))]
+    pub static_dir: Option<PathBuf>,
     /// The path to the configuration file. [default: ./config.toml]
     #[clap(long, short = 'c', env = "HEARTBEAT_CONFIG_FILE")]
     pub config_file: Option<PathBuf>,
@@ -78,6 +82,9 @@ pub struct Config {
     pub live_url: String,
     /// The bind address for the server.
     pub bind: SocketAddr,
+    /// Path to the directory containing static files.
+    #[cfg(not(feature = "embed"))]
+    pub static_dir: PathBuf,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -280,6 +287,9 @@ impl<'a> Merge<'a> {
         SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 6060))
     );
 
+    #[cfg(not(feature = "embed"))]
+    config_field!(static_dir, PathBuf, PathBuf::from("./static"));
+
     pub fn try_into(self) -> Result<Config, Error> {
         Ok(Config {
             database: Database {
@@ -295,6 +305,8 @@ impl<'a> Merge<'a> {
             server_name: self.server_name()?,
             live_url: self.live_url()?,
             bind: self.bind()?,
+            #[cfg(not(feature = "embed"))]
+            static_dir: self.static_dir()?,
         })
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -53,9 +53,19 @@ pub struct Cli {
     /// The bind address for the server.
     #[clap(long, short, env = "HEARTBEAT_BIND")]
     pub bind: Option<SocketAddr>,
-    /// Path to the directory containing static assets. [default: ./static]
-    #[cfg(not(feature = "embed"))]
-    #[cfg_attr(not(feature = "embed"), clap(long, env = "HEARTBEAT_STATIC_DIR"))]
+    // Not gating this behind `not(feature = "embed")` because rust-analyzer
+    // doesn't understand it.
+    // probably because of https://github.com/rust-lang/rust-analyzer/issues/8434
+    // instead we just explain that it does nothing in the help text.
+    #[cfg_attr(
+        not(feature = "embed"),
+        doc = "Path to the directory containing static assets. [default: ./static]"
+    )]
+    #[cfg_attr(
+        feature = "embed",
+        doc = "This option is ignored because this binary has static assets embedded in it."
+    )]
+    #[clap(long, env = "HEARTBEAT_STATIC_DIR")]
     pub static_dir: Option<PathBuf>,
     /// The path to the configuration file. [default: ./config.toml]
     #[clap(long, short = 'c', env = "HEARTBEAT_CONFIG_FILE")]

--- a/src/config.rs
+++ b/src/config.rs
@@ -53,9 +53,6 @@ pub struct Cli {
     /// The bind address for the server.
     #[clap(long, short, env = "HEARTBEAT_BIND")]
     pub bind: Option<SocketAddr>,
-    /// Path to the directory containing static files. [default: ./static]
-    #[clap(long, env = "HEARTBEAT_STATIC_DIR")]
-    pub static_dir: Option<PathBuf>,
     /// The path to the configuration file. [default: ./config.toml]
     #[clap(long, short = 'c', env = "HEARTBEAT_CONFIG_FILE")]
     pub config_file: Option<PathBuf>,
@@ -81,8 +78,6 @@ pub struct Config {
     pub live_url: String,
     /// The bind address for the server.
     pub bind: SocketAddr,
-    /// Path to the directory containing static files.
-    pub static_dir: PathBuf,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -285,8 +280,6 @@ impl<'a> Merge<'a> {
         SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 6060))
     );
 
-    config_field!(static_dir, PathBuf, PathBuf::from("./static"));
-
     pub fn try_into(self) -> Result<Config, Error> {
         Ok(Config {
             database: Database {
@@ -302,7 +295,6 @@ impl<'a> Merge<'a> {
             server_name: self.server_name()?,
             live_url: self.live_url()?,
             bind: self.bind()?,
-            static_dir: self.static_dir()?,
         })
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,8 @@ pub use error::handle_errors;
 
 /// Crate version and git commit hash.
 pub const VERSION: &str = env!("HB_VERSION");
+/// Embedded static assets.
+pub const ASSETS: include_dir::Dir = include_dir::include_dir!("static");
 
 /// Like [`tracing_subscriber::fmt::init`], but defaults to DEBUG on
 /// debug builds.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,7 @@ pub use error::handle_errors;
 /// Crate version and git commit hash.
 pub const VERSION: &str = env!("HB_VERSION");
 /// Embedded static assets.
+#[cfg(feature = "embed")]
 pub const ASSETS: include_dir::Dir = include_dir::include_dir!("static");
 
 /// Like [`tracing_subscriber::fmt::init`], but defaults to DEBUG on

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,9 +36,6 @@ pub use error::handle_errors;
 
 /// Crate version and git commit hash.
 pub const VERSION: &str = env!("HB_VERSION");
-/// Embedded static assets.
-#[cfg(feature = "embed")]
-pub const ASSETS: include_dir::Dir = include_dir::include_dir!("static");
 
 /// Like [`tracing_subscriber::fmt::init`], but defaults to DEBUG on
 /// debug builds.

--- a/src/routes/assets.rs
+++ b/src/routes/assets.rs
@@ -1,0 +1,54 @@
+use std::path::{Component, Path, PathBuf};
+
+use axum::{
+    http::{header, StatusCode, Uri},
+    response::{IntoResponse, Response},
+};
+
+#[derive(Clone, rust_embed::RustEmbed)]
+#[folder = "static"]
+pub struct Static;
+
+pub(super) async fn serve_static_file(uri: Uri) -> StaticFile {
+    let path = uri.path().trim_start_matches('/');
+    StaticFile(build_and_validate_path(path))
+}
+
+pub struct StaticFile(Option<PathBuf>);
+
+impl IntoResponse for StaticFile {
+    fn into_response(self) -> Response {
+        let Some(path) = self.0 else {
+            return (StatusCode::NOT_FOUND, "Not found").into_response();
+        };
+        match Static::get(&path.as_path().to_string_lossy()) {
+            Some(content) => {
+                let mime = mime_guess::from_path(&path).first_or_octet_stream();
+                ([(header::CONTENT_TYPE, mime.as_ref())], content.data).into_response()
+            }
+            None => (StatusCode::NOT_FOUND, "Not found").into_response(),
+        }
+    }
+}
+
+fn build_and_validate_path(requested_path: &str) -> Option<PathBuf> {
+    let path_decoded = percent_encoding::percent_decode(requested_path.as_ref())
+        .decode_utf8()
+        .ok()?;
+    let path_decoded = Path::new(&*path_decoded);
+    let mut ret = PathBuf::new();
+    for component in path_decoded.components() {
+        match component {
+            Component::Normal(comp) => {
+                if Path::new(&comp).components().all(|c| matches!(c, Component::Normal(_))) {
+                    ret.push(comp);
+                } else {
+                    return None;
+                }
+            }
+            Component::CurDir => {}
+            Component::Prefix(_) | Component::RootDir | Component::ParentDir => return None,
+        }
+    }
+    Some(ret)
+}

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -24,6 +24,7 @@ use badge_routes::{last_seen, total_beats};
 use pages::{index_page, privacy_page, stats_page};
 
 mod api;
+mod assets;
 #[cfg(feature = "badges")]
 #[path = "badges.rs"]
 mod badge_routes;
@@ -36,6 +37,10 @@ pub(crate) async fn health_check() -> &'static str {
 /// Creates and returns a [`Router`] with only the routes determined by
 /// crate features and the provided [`Config`].
 pub fn router(config: &Config) -> Router<AppState> {
+    __router(config).route("/*file", get(assets::serve_static_file))
+}
+
+fn __router(config: &Config) -> Router<AppState> {
     let mut router = Router::new()
         .route("/", get(index_page))
         .route("/.well-known/health", get(health_check))


### PR DESCRIPTION
Use [`include_dir`](https://lib.rs/crates/include_dir) to embed the static assets into the binary so that it can be distributed easily.